### PR TITLE
Add Helm chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: "CLEAN Frontend"
+name: clean-frontend
+version: 1.0.0

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Application is now running!
+
+Access http{{- if .Values.ingress.tls }}s{{end}}://{{ .Values.ingress.hostname }} to access the CLEAN frontend

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,24 @@
+# Defines the deployment of the app running in a pod on any worker node
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: clean-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clean-frontend
+  template:
+    metadata:
+      labels:
+        app: clean-frontend
+    spec:
+      containers:
+        - name: clean-frontend
+          image: {{ .Values.controller.image }}
+
+          ports:
+            - containerPort: 80
+          imagePullPolicy: Always

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,30 @@
+# Enables the pods in a deployment to be accessible from outside the cluster
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: clean-frontend
+{{- with .Values.ingress.annotations }}
+  annotations:
+  {{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.hostname }}
+    secretName: {{ .Values.ingress.hostname }}-tls
+{{- end }}
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+  rules:
+  - host: {{ .Values.ingress.hostname | required "required: ingress.hostname (e.g. clean.frontend.localhost)" }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  selector:
+    app: clean-frontend
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 80
+      targetPort: 80

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -1,0 +1,3 @@
+ingress:
+  ingressClassName: nginx
+

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -1,0 +1,8 @@
+ingress:
+  hostname: clean.frontend.mmli1.ncsa.illinois.edu
+  tls: true
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/tls-acme: "true"
+    traefik.ingress.kubernetes.io/router.tls: "true"
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,8 @@
+ingress:
+  hostname: clean.frontend.localhost
+  tls: false
+  annotations: {}
+
+controller:
+  image: moleculemaker/clean-frontend
+


### PR DESCRIPTION
## Problem
We need an automated way to deploy / iterate on changes during development to this product

## Approach
* Add simple Helm chart based on existing recipe for the [DMM frontend](https://github.com/moleculemaker/digital-molecule-maker/tree/develop/chart)
* Included basic `prod` configuration as well, and a `local` configuration for testing things locally

## How to Test
Prerequisites: Docker for Mac/Windows, Kubernetes enabled, kubeconfig pointing at local cluster

1. Checkout and run this branch locally, run from the chart folder: `cd chart/`
2. Install the chart with `local` configuration: `helm upgrade --install clean-frontend -n clean --create-namespace . -f values.local.yaml`
    * You should see the `clean-frontend` application is deployed into the `clean` namespace
3. Navigate to http://clean.frontend.localhost in your browser
    * You should see the CLEAN frontend application load in your browser