### PR TITLE
tracked number of sequences submitted in job

### DIFF
--- a/src/app/sequence.service.ts
+++ b/src/app/sequence.service.ts
@@ -6,6 +6,7 @@ import { PostResponse, PostSeqData, ExampleData, PostEmailResponse } from './mod
 import { EnvironmentService } from "./services/environment.service";
 import { EnvVars } from "./models/envvars";
 import {Job, JobsService} from "./api/mmli-backend/v1";
+import { TrackingService } from './tracking.service';
 
 @Injectable({
   providedIn: 'root'
@@ -40,7 +41,12 @@ export class SequenceService {
     return `${this.hostname}/${this.apiBasePath}`;
   }
 
-  constructor(private http: HttpClient, private envService: EnvironmentService, private jobsApi: JobsService) {
+  constructor(
+    private http: HttpClient,
+    private envService: EnvironmentService,
+    private jobsApi: JobsService,
+    private trackingService: TrackingService
+  ) {
     this.envs = this.envService.getEnvConfig();
   }
 
@@ -58,6 +64,7 @@ export class SequenceService {
 
 
   getResponse(sequenceData: PostSeqData): Observable<Job>{
+    this.trackingService.trackJobSubmission(sequenceData);
     return this.jobsApi.createJobJobTypeJobsPost('clean', {
       email: sequenceData.user_email,
       job_info: JSON.stringify({ 'input_fasta': sequenceData.input_fasta })

--- a/src/app/tracking.service.ts
+++ b/src/app/tracking.service.ts
@@ -10,6 +10,8 @@
 import { Injectable } from '@angular/core';
 import { MatomoTracker } from '@ngx-matomo/tracker';
 
+import { PostSeqData } from './models';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -33,6 +35,10 @@ export class TrackingService {
 
   trackSelectExampleData(exampleDataSet: string): void {
     this.tracker.trackEvent('Configuration', 'Select example data', exampleDataSet);
+  }
+
+  trackJobSubmission(postSeqData: PostSeqData): void {
+    this.tracker.trackEvent('Sequence Service', 'Create Job', 'Number of sequences', postSeqData.input_fasta.length);
   }
 }
 


### PR DESCRIPTION
This PR uses Matomo to track the number of sequences submitted with each job. The total number of sequences processed is one of the metrics we report to NSF.

Eventually we'll want to track this on the backend, too, because adblockers might prevent Matomo from recording data from some users. (In the meantime, we have a manual procedure to count sequences on the backend.)