### PR TITLE
feat: switch to ibiofoundry hostname

### DIFF
--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -1,17 +1,22 @@
 ingress:
-  hostname: clean.platform.moleculemaker.org
+  hostname: clean.platform.ibiofoundry.illinois.edu
   extraHosts:
   - clean.frontend.mmli2.ncsa.illinois.edu
+  - clean.platform.moleculemaker.org
   tls: true
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-production"
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.middlewares: "alphasynthesis-clean-prod-domain-redirect@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "alphasynthesis-clean-prod-domain-redirect@kubernetescrd,alphasynthesis-clean-prod-domain-redirect-ibiofoundry@kubernetescrd"
 
 config:
+  # TODO: add *.platform.ibiofoundry.illinois.edu to CORS
   hostname: "https://mmli.fastapi.mmli2.ncsa.illinois.edu"
   basePath: ""
+
+  # TODO: existing auth server won't work for ibiofoundry.illinois.edu - this will need a custom OAuth2 Proxy deployment
+  # TODO: is there a more generic way to handle this?
   signInUrl: "https://auth.platform.moleculemaker.org/oauth2/start?rd=https%3A%2F%2Fclean.platform.moleculemaker.org%2Fconfiguration"
   signOutUrl: "https://auth.platform.moleculemaker.org/oauth2/sign_out?rd=https%3A%2F%2Fclean.platform.moleculemaker.org%2Fconfiguration"
   userInfoUrl: "https://auth.platform.moleculemaker.org/oauth2/userinfo"
@@ -26,5 +31,16 @@ extraDeploy:
   spec:
     redirectRegex:
       regex: "^https://clean.frontend.mmli2.ncsa.illinois.edu/(.*)"
-      replacement: "https://clean.platform.moleculemaker.org/${1}"
+      replacement: "https://clean.platform.ibiofoundry.illinois.edu/${1}"
+      permanent: true
+      
+- apiVersion: traefik.io/v1alpha1
+  kind: Middleware
+  metadata:
+    name: clean-prod-domain-redirect-ibiofoundry
+    namespace: alphasynthesis
+  spec:
+    redirectRegex:
+      regex: "^https://clean.platform.moleculemaker.org/(.*)"
+      replacement: "https://clean.platform.ibiofoundry.illinois.edu/${1}"
       permanent: true

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -1,17 +1,22 @@
 ingress:
-  hostname: clean.platform.moleculemaker.org
+  hostname: clean.platform.ibiofoundry.illinois.edu
   extraHosts:
   - clean.frontend.mmli1.ncsa.illinois.edu
+  - clean.platform.moleculemaker.org
   tls: true
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-production"
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.middlewares: "alphasynthesis-clean-prod-domain-redirect@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "alphasynthesis-clean-prod-domain-redirect@kubernetescrd,alphasynthesis-clean-prod-domain-redirect-ibiofoundry@kubernetescrd"
 
 config:
+  # TODO: add *.platform.ibiofoundry.illinois.edu to CORS
   hostname: "https://mmli.fastapi.mmli1.ncsa.illinois.edu"
   basePath: ""
+
+  # TODO: existing auth server won't work for ibiofoundry.illinois.edu - this will need a custom OAuth2 Proxy deployment
+  # TODO: is there a more generic way to handle this?
   signInUrl: "https://auth.platform.moleculemaker.org/oauth2/start?rd=https%3A%2F%2Fclean.platform.moleculemaker.org%2Fconfiguration"
   signOutUrl: "https://auth.platform.moleculemaker.org/oauth2/sign_out?rd=https%3A%2F%2Fclean.platform.moleculemaker.org%2Fconfiguration"
   userInfoUrl: "https://auth.platform.moleculemaker.org/oauth2/userinfo"
@@ -26,5 +31,16 @@ extraDeploy:
   spec:
     redirectRegex:
       regex: "^https://clean.frontend.mmli1.ncsa.illinois.edu/(.*)"
-      replacement: "https://clean.platform.moleculemaker.org/${1}"
+      replacement: "https://clean.platform.ibiofoundry.illinois.edu/${1}"
+      permanent: true
+      
+- apiVersion: traefik.io/v1alpha1
+  kind: Middleware
+  metadata:
+    name: clean-prod-domain-redirect-ibiofoundry
+    namespace: alphasynthesis
+  spec:
+    redirectRegex:
+      regex: "^https://clean.platform.moleculemaker.org/(.*)"
+      replacement: "https://clean.platform.ibiofoundry.illinois.edu/${1}"
       permanent: true


### PR DESCRIPTION
## Problem
We would like to serve a copy of this page at `clean.platform.ibiofoundry.illinois.edu`

## Approach
* wip: serve at ibiofoundry host, redirect others to ibiofoundry (see comments for next steps)

~~**DO NOT MERGE** until the DNS rule has been set up for `*.platform.ibiofoundry.illinois.edu`~~ DNS rule has been created :+1:

### TODOs
* New OAuth2 proxy instance needed to manage the new domain `*.platform.ibiofoundry.illinois.edu`
* Add new domain to existing CORS rules throughout (maybe utilize wildcards more frequently in CORS rules)
* need to revisit CLEAN job success/failed emails, which may no longer contain the correct hostname
* New Keycloak realm?

### Considerations
With this approach, the URL would always say `clean.platform.ibiofoundry.illinois.edu`

The following hosts will redirect to this new hostname:
* `clean.platform.moleculemaker.org` -> `clean.platform.ibiofoundry.illinois.edu`
* `clean.frontend.mmli1.ncsa.illinois.edu` -> `clean.platform.ibiofoundry.illinois.edu`

## How to Test
1. Navigate to https://clean.platform.ibiofoundry.illinois.edu/configuration
    * You should see the familiar CLEAN app
2. Navigate to https://clean.platform.moleculemaker.org/configuration
    * You should see the same familiar CLEAN app
    * NOTE: this is a single container of `clean-frontend` running with 2 separate hostnames, and currently both hostnames should be allowed to be used
    * Also noting that this case should actually FAIL, but for some reason right now it is succeeding.. which leaves me with other questions 😅 

